### PR TITLE
emsdk 3.1.74 compatibility

### DIFF
--- a/3rdparty/sol2/sol/sol.hpp
+++ b/3rdparty/sol2/sol/sol.hpp
@@ -6056,7 +6056,8 @@ namespace sol {
 			static_assert(std::is_constructible<T, Args&&...>::value, "T must be constructible with Args");
 
 			*this = nullopt;
-			this->construct(std::forward<Args>(args)...);
+			new (static_cast<void*>(this)) optional(std::in_place, std::forward<Args>(args)...);
+			return **this;
 		}
 
 		/// Swaps this optional with the other.

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -234,6 +234,7 @@ build:
 	@mv $(SUBTARGET)_libretro.so $(SAME_SYSTEM)_libretro.so 2> /dev/null || true
 	@mv $(SUBTARGET)_libretro_android.so $(SAME_SYSTEM)_libretro_android.so 2> /dev/null || true
 	$(AR) -crs $(SAME_SYSTEM)_libretro_emscripten.bc $(SUBTARGET)_libretro_emscripten.bc 2> /dev/null || true
+	@rm -rf $(SUBTARGET)_libretro_emscripten.bc
 	@echo "Done!"
 
 vs2015:

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -1172,7 +1172,6 @@ configuration { "asmjs" }
 		"-O" .. _OPTIONS["OPTIMIZE"],
 		"-s USE_SDL=2",
 		"-s USE_SDL_TTF=2",
-		"--memory-init-file 0",
 		"-s EXPORTED_FUNCTIONS=\"['_main', '_malloc', '__ZN15running_machine30emscripten_get_running_machineEv', '__ZN15running_machine17emscripten_get_uiEv', '__ZN15running_machine20emscripten_get_soundEv', '__ZN15mame_ui_manager12set_show_fpsEb', '__ZNK15mame_ui_manager8show_fpsEv', '__ZN13sound_manager4muteEbh', '_SDL_PauseAudio', '_SDL_SendKeyboardKey', '__ZN15running_machine15emscripten_saveEPKc', '__ZN15running_machine15emscripten_loadEPKc', '__ZN15running_machine21emscripten_hard_resetEv', '__ZN15running_machine21emscripten_soft_resetEv', '__ZN15running_machine15emscripten_exitEv']\"",
 		"-s EXPORTED_RUNTIME_METHODS=\"['cwrap']\"",
 		"-s ERROR_ON_UNDEFINED_SYMBOLS=0",


### PR DESCRIPTION
Made adjustments for the same_cdi core to compile against emsdk 3.1.74

The sol library was not building; patched a fix from a commit for sol 3.5.0 manually as it is not released (see https://github.com/ThePhD/sol2/issues/1617).

Removed mess_libretro_emscripten.bc file as it confuses the rest of the build script since it moves *.bc files.

--memory-init-file option is no longer supported.